### PR TITLE
 Bug Fix

### DIFF
--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
@@ -34,7 +34,8 @@
          "in_list_view": 1,
          "label": "Payment Term",
          "options": "Payment Term",
-         "print_hide": 1
+         "print_hide": 1,
+         "read_only": 1
         },
         {
          "columns": 2,
@@ -42,7 +43,8 @@
          "fieldname": "description",
          "fieldtype": "Small Text",
          "in_list_view": 1,
-         "label": "Description"
+         "label": "Description",
+         "read_only": 1
         },
         {
          "columns": 2,
@@ -57,7 +59,8 @@
          "fieldtype": "Percent",
          "in_list_view": 1,
          "label": "Invoice Portion",
-         "print_hide": 1
+         "print_hide": 1,
+         "read_only": 1
         },
         {
          "columns": 2,
@@ -66,6 +69,7 @@
          "in_list_view": 1,
          "label": "Payment Amount",
          "options": "currency",
+         "read_only": 1,
          "reqd": 1
         },
         {
@@ -158,7 +162,7 @@
     "index_web_pages_for_search": 1,
     "istable": 1,
     "links": [],
-    "modified": "2022-09-05 07:16:55.130950",
+    "modified": "2022-09-19 04:28:15.553957",
     "modified_by": "Administrator",
     "module": "Accounts",
     "name": "Payment Schedule",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -896,7 +896,8 @@
       "fieldname": "payment_terms_template",
       "fieldtype": "Link",
       "label": "Payment Terms Template",
-      "options": "Payment Terms Template"
+      "options": "Payment Terms Template",
+      "read_only": 1
      },
      {
       "fieldname": "payment_schedule",
@@ -1244,7 +1245,7 @@
     "idx": 105,
     "is_submittable": 1,
     "links": [],
-    "modified": "2022-07-22 05:15:17.918730",
+    "modified": "2022-09-19 04:34:52.896947",
     "modified_by": "Administrator",
     "module": "Buying",
     "name": "Purchase Order",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -371,10 +371,10 @@
      {
       "fieldname": "contact_email",
       "fieldtype": "Small Text",
+      "hidden": 1,
       "label": "Contact Email",
       "options": "Email",
-      "print_hide": 1,
-      "read_only": 1
+      "print_hide": 1
      },
      {
       "fieldname": "col_break_address",
@@ -1245,7 +1245,7 @@
     "idx": 105,
     "is_submittable": 1,
     "links": [],
-    "modified": "2022-09-19 04:34:52.896947",
+    "modified": "2022-09-20 01:23:07.743984",
     "modified_by": "Administrator",
     "module": "Buying",
     "name": "Purchase Order",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -315,7 +315,12 @@ class PurchaseReceipt(BuyingController):
 					d.db_set('batch_no', '')
 					frappe.delete_doc('Batch', delete_batch)
 					d.batch_no = d.get("batch_number")
-					
+
+	def validate(self):
+		for d in self.get("items"):
+			if d.manufacturing_date >= d.expiry_date:
+				frappe.throw(_("Expiry Date {0},Cannot Be Select Before or Same  Manufacturing Date {1}"). format(d.expiry_date,d.manufacturing_date))
+
 	def make_item_gl_entries(self, gl_entries, warehouse_account=None):
 		if erpnext.is_perpetual_inventory_enabled(self.company):
 			stock_rbnb = self.get_company_default("stock_received_but_not_billed")

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -1023,17 +1023,20 @@
         },
         {
             "columns": 1,
+            "default": "Today",
             "fieldname": "manufacturing_date",
             "fieldtype": "Date",
             "in_list_view": 1,
-            "label": "Manufacturing Date"
+            "label": "Manufacturing Date",
+            "reqd": 1
         },
         {
             "columns": 1,
             "fieldname": "expiry_date",
             "fieldtype": "Date",
             "in_list_view": 1,
-            "label": "Expiry Date"
+            "label": "Expiry Date",
+            "reqd": 1
         },
         {
             "fieldname": "column_break_49",
@@ -1052,13 +1055,14 @@
             "fieldname": "batch_number",
             "fieldtype": "Data",
             "in_list_view": 1,
-            "label": "Batch No"
+            "label": "Batch No",
+            "reqd": 1
         }
     ],
     "idx": 1,
     "istable": 1,
     "links": [],
-    "modified": "2022-08-01 04:00:32.435383",
+    "modified": "2022-09-19 05:46:54.085619",
     "modified_by": "Administrator",
     "module": "Stock",
     "name": "Purchase Receipt Item",


### PR DESCRIPTION
UNI-0022--When I update the PO status to ready to PO at that time, I enter the same date in both the manufacturing date and expiry date fields, and it is accepted and no error is shown.--Done

UNI-0014--Click on purchase order with open status >>Update status>>Ready to PO and creating the new Batch No if the user selects the expiry date before the manufacturing date data is saved but the error message is displayed after submitting the PO.--Done

UNI-0020---When I create a PO, in the terms of payment section, when we change payment terms in the payment schedule table, it does not change in the payment terms template field and the PO is also submitted.--Done

UNI-0017-(Mandatory Manufacturing,Expiry Date and Batch No) --->- While I change the status of an open PO to ready PO, and while I try to save that PO without entering Manufacturing Date and Expiry Date, the system allows the submitted PO and also shows an error " value missing for Manufacturing Date and Expiry Date."--Done
-UNI-0018--While I change the status of an open PO to ready PO, the Manufacturing Date is by default added as today's date in the product detail section.--Done
UNI-0025-Batch no. is also a mandatory field, so the 1st error displays the missing batch no.--Done
UNI-0029--While I create a logistic notice and fill in the shipping details and click on the save and submit button, a pop-up window opens and asks for permanent submission and I click on yes. The message is shows click the "ship button first before submitting record", but there is one mandatory field "confirmed shipping" and if it is left blank, no error is shown.