### PR TITLE
PO to PR flow change and status update.

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -1,1309 +1,1324 @@
 {
-    "actions": [],
-    "allow_auto_repeat": 1,
-    "allow_import": 1,
-    "autoname": "naming_series:",
-    "creation": "2013-05-21 16:16:39",
-    "doctype": "DocType",
-    "document_type": "Document",
-    "engine": "InnoDB",
-    "field_order": [
-     "supplier_section",
-     "naming_series",
-     "section_break_3",
-     "title",
-     "get_items_from_open_material_requests",
-     "apply_tds",
-     "tax_withholding_category",
-     "column_break1",
-     "company",
-     "schedule_date",
-     "order_confirmation_no",
-     "order_confirmation_date",
-     "amended_from",
-     "accounting_dimensions_section",
-     "cost_center",
-     "dimension_col_break",
-     "project",
-     "drop_ship",
-     "customer",
-     "customer_name",
-     "column_break_19",
-     "customer_contact_person",
-     "customer_contact_display",
-     "customer_contact_mobile",
-     "customer_contact_email",
-     "supplier_name",
-     "section_addresses",
-     "supplier",
-     "column_break_29",
-     "address_display",
-     "supplier_code",
-     "supplier_address",
-     "contact_person",
-     "contact_display",
-     "contact_mobile",
-     "contact_email",
-     "col_break_address",
-     "shipping_address",
-     "shipping_address_display",
-     "billing_address",
-     "billing_address_display",
-     "transaction_date",
-     "proposed_ready_date",
-     "ready_date",
-     "currency_and_price_list",
-     "currency",
-     "conversion_rate",
-     "cb_price_list",
-     "buying_price_list",
-     "price_list_currency",
-     "plc_conversion_rate",
-     "ignore_pricing_rule",
-     "sec_warehouse",
-     "is_subcontracted",
-     "col_break_warehouse",
-     "supplier_warehouse",
-     "before_items_section",
-     "scan_barcode",
-     "items_col_break",
-     "set_warehouse",
-     "items_section",
-     "items",
-     "sb_last_purchase",
-     "total_qty",
-     "base_total",
-     "base_net_total",
-     "column_break_26",
-     "total_net_weight",
-     "total",
-     "net_total",
-     "section_break_48",
-     "pricing_rules",
-     "raw_material_details",
-     "set_reserve_warehouse",
-     "supplied_items",
-     "taxes_section",
-     "tax_category",
-     "column_break_50",
-     "shipping_rule",
-     "section_break_52",
-     "taxes_and_charges",
-     "taxes",
-     "sec_tax_breakup",
-     "other_charges_calculation",
-     "totals",
-     "base_taxes_and_charges_added",
-     "base_taxes_and_charges_deducted",
-     "base_total_taxes_and_charges",
-     "column_break_39",
-     "taxes_and_charges_added",
-     "taxes_and_charges_deducted",
-     "total_taxes_and_charges",
-     "discount_section",
-     "apply_discount_on",
-     "base_discount_amount",
-     "column_break_45",
-     "additional_discount_percentage",
-     "discount_amount",
-     "totals_section",
-     "base_grand_total",
-     "base_rounding_adjustment",
-     "base_in_words",
-     "base_rounded_total",
-     "column_break4",
-     "grand_total",
-     "rounding_adjustment",
-     "rounded_total",
-     "disable_rounded_total",
-     "in_words",
-     "advance_paid",
-     "payment_schedule_section",
-     "payment_terms_template",
-     "payment_schedule",
-     "tracking_section",
-     "status",
-     "po_status",
-     "column_break_75",
-     "per_billed",
-     "per_received",
-     "terms_section_break",
-     "tc_name",
-     "terms",
-     "column_break5",
-     "letter_head",
-     "select_print_heading",
-     "column_break_86",
-     "language",
-     "group_same_items",
-     "subscription_section",
-     "from_date",
-     "to_date",
-     "column_break_97",
-     "auto_repeat",
-     "update_auto_repeat_reference",
-     "more_info",
-     "ref_sq",
-     "column_break_74",
-     "party_account_currency",
-     "is_internal_supplier",
-     "represents_company",
-     "inter_company_order_reference"
-    ],
-    "fields": [
-     {
-      "fieldname": "supplier_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "options": "fa fa-user"
-     },
-     {
-      "allow_on_submit": 1,
-      "default": "{supplier_name}",
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Title",
-      "no_copy": 1,
-      "print_hide": 1
-     },
-     {
-      "default": ".supplier_code.-.##.-.YYYY.",
-      "fieldname": "naming_series",
-      "fieldtype": "Select",
-      "hidden": 1,
-      "label": "Series",
-      "no_copy": 1,
-      "oldfieldname": "naming_series",
-      "oldfieldtype": "Select",
-      "options": "PUR-ORD-.YYYY.-\n.supplier_code.-.##.-.YYYY.",
-      "print_hide": 1,
-      "set_only_once": 1
-     },
-     {
-      "bold": 1,
-      "fieldname": "supplier",
-      "fieldtype": "Link",
-      "in_global_search": 1,
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Supplier",
-      "oldfieldname": "supplier",
-      "oldfieldtype": "Link",
-      "options": "Supplier",
-      "print_hide": 1,
-      "reqd": 1,
-      "search_index": 1
-     },
-     {
-      "depends_on": "eval:doc.supplier && doc.docstatus===0 && (!(doc.items && doc.items.length) || (doc.items.length==1 && !doc.items[0].item_code))",
-      "description": "Fetch items based on Default Supplier.",
-      "fieldname": "get_items_from_open_material_requests",
-      "fieldtype": "Button",
-      "hidden": 1,
-      "label": "Get Items from Open Material Requests"
-     },
-     {
-      "fetch_from": "supplier.supplier_name",
-      "fieldname": "supplier_name",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Supplier Name",
-      "read_only": 1
-     },
-     {
-      "fieldname": "company",
-      "fieldtype": "Link",
-      "label": "Company",
-      "oldfieldname": "company",
-      "oldfieldtype": "Link",
-      "options": "Company",
-      "print_hide": 1,
-      "remember_last_selected_value": 1
-     },
-     {
-      "fieldname": "column_break1",
-      "fieldtype": "Column Break",
-      "oldfieldtype": "Column Break",
-      "print_width": "50%",
-      "width": "50%"
-     },
-     {
-      "default": "Today",
-      "fieldname": "transaction_date",
-      "fieldtype": "Date",
-      "in_list_view": 1,
-      "label": "Date",
-      "oldfieldname": "transaction_date",
-      "oldfieldtype": "Date",
-      "search_index": 1
-     },
-     {
-      "allow_on_submit": 1,
-      "default": "2099-12-31",
-      "fieldname": "schedule_date",
-      "fieldtype": "Date",
-      "hidden": 1,
-      "label": "Required By"
-     },
-     {
-      "allow_on_submit": 1,
-      "depends_on": "eval:doc.docstatus===1",
-      "fieldname": "order_confirmation_no",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Order Confirmation No"
-     },
-     {
-      "allow_on_submit": 1,
-      "depends_on": "eval:doc.order_confirmation_no",
-      "fieldname": "order_confirmation_date",
-      "fieldtype": "Date",
-      "label": "Order Confirmation Date"
-     },
-     {
-      "fieldname": "amended_from",
-      "fieldtype": "Link",
-      "ignore_user_permissions": 1,
-      "label": "Amended From",
-      "no_copy": 1,
-      "oldfieldname": "amended_from",
-      "oldfieldtype": "Data",
-      "options": "Purchase Order",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "drop_ship",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Drop Ship"
-     },
-     {
-      "fieldname": "customer",
-      "fieldtype": "Link",
-      "label": "Customer",
-      "options": "Customer",
-      "read_only": 1
-     },
-     {
-      "bold": 1,
-      "fieldname": "customer_name",
-      "fieldtype": "Data",
-      "label": "Customer Name",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break_19",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "customer_contact_person",
-      "fieldtype": "Link",
-      "label": "Customer Contact",
-      "options": "Contact"
-     },
-     {
-      "fieldname": "customer_contact_display",
-      "fieldtype": "Small Text",
-      "hidden": 1,
-      "label": "Customer Contact",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "customer_contact_mobile",
-      "fieldtype": "Small Text",
-      "hidden": 1,
-      "label": "Customer Mobile No",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "customer_contact_email",
-      "fieldtype": "Code",
-      "hidden": 1,
-      "label": "Customer Contact Email",
-      "options": "Email",
-      "print_hide": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "section_addresses",
-      "fieldtype": "Section Break"
-     },
-     {
-      "fieldname": "supplier_address",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Supplier Address Details",
-      "options": "Address",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "contact_person",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Supplier Contact",
-      "options": "Contact",
-      "print_hide": 1
-     },
-     {
-      "depends_on": "eval:doc.supplier",
-      "fieldname": "address_display",
-      "fieldtype": "Small Text",
-      "label": "Supplier Address",
-      "read_only": 1
-     },
-     {
-      "fieldname": "contact_display",
-      "fieldtype": "Small Text",
-      "hidden": 1,
-      "in_global_search": 1,
-      "label": "Contact Name",
-      "read_only": 1
-     },
-     {
-      "fieldname": "contact_mobile",
-      "fieldtype": "Small Text",
-      "hidden": 1,
-      "label": "Contact Mobile No",
-      "read_only": 1
-     },
-     {
-      "fieldname": "contact_email",
-      "fieldtype": "Small Text",
-      "hidden": 1,
-      "label": "Contact Email",
-      "options": "Email",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "col_break_address",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "shipping_address",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Company Shipping Address",
-      "options": "Address",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "shipping_address_display",
-      "fieldtype": "Small Text",
-      "label": "Shipping Address Details",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "currency_and_price_list",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Currency and Price List",
-      "options": "fa fa-tag"
-     },
-     {
-      "fieldname": "currency",
-      "fieldtype": "Link",
-      "label": "Currency",
-      "oldfieldname": "currency",
-      "oldfieldtype": "Select",
-      "options": "Currency",
-      "print_hide": 1,
-      "reqd": 1
-     },
-     {
-      "fieldname": "conversion_rate",
-      "fieldtype": "Float",
-      "label": "Exchange Rate",
-      "oldfieldname": "conversion_rate",
-      "oldfieldtype": "Currency",
-      "precision": "9",
-      "print_hide": 1,
-      "reqd": 1
-     },
-     {
-      "fieldname": "cb_price_list",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "buying_price_list",
-      "fieldtype": "Link",
-      "label": "Price List",
-      "options": "Price List",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "price_list_currency",
-      "fieldtype": "Link",
-      "label": "Price List Currency",
-      "options": "Currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "plc_conversion_rate",
-      "fieldtype": "Float",
-      "label": "Price List Exchange Rate",
-      "precision": "9",
-      "print_hide": 1
-     },
-     {
-      "default": "0",
-      "fieldname": "ignore_pricing_rule",
-      "fieldtype": "Check",
-      "label": "Ignore Pricing Rule",
-      "no_copy": 1,
-      "permlevel": 1,
-      "print_hide": 1
-     },
-     {
-      "fieldname": "sec_warehouse",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Subcontracting"
-     },
-     {
-      "description": "Sets 'Warehouse' in each row of the Items table.",
-      "fieldname": "set_warehouse",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Set Target Warehouse",
-      "options": "Warehouse",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "col_break_warehouse",
-      "fieldtype": "Column Break"
-     },
-     {
-      "default": "No",
-      "fieldname": "is_subcontracted",
-      "fieldtype": "Select",
-      "label": "Supply Raw Materials",
-      "options": "No\nYes",
-      "print_hide": 1
-     },
-     {
-      "depends_on": "eval:doc.is_subcontracted==\"Yes\"",
-      "fieldname": "supplier_warehouse",
-      "fieldtype": "Link",
-      "label": "Supplier Warehouse",
-      "options": "Warehouse"
-     },
-     {
-      "fieldname": "items_section",
-      "fieldtype": "Section Break",
-      "hide_border": 1,
-      "oldfieldtype": "Section Break",
-      "options": "fa fa-shopping-cart"
-     },
-     {
-      "fieldname": "scan_barcode",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Scan Barcode",
-      "options": "Barcode"
-     },
-     {
-      "fieldname": "items",
-      "fieldtype": "Table",
-      "label": "Product",
-      "oldfieldname": "po_details",
-      "oldfieldtype": "Table",
-      "options": "Purchase Order Item",
-      "reqd": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "section_break_48",
-      "fieldtype": "Section Break",
-      "label": "Pricing Rules"
-     },
-     {
-      "fieldname": "pricing_rules",
-      "fieldtype": "Table",
-      "label": "Purchase Order Pricing Rule",
-      "options": "Pricing Rule Detail",
-      "read_only": 1
-     },
-     {
-      "collapsible_depends_on": "supplied_items",
-      "fieldname": "raw_material_details",
-      "fieldtype": "Section Break",
-      "label": "Raw Materials Supplied"
-     },
-     {
-      "fieldname": "supplied_items",
-      "fieldtype": "Table",
-      "label": "Supplied Items",
-      "no_copy": 1,
-      "oldfieldname": "po_raw_material_details",
-      "oldfieldtype": "Table",
-      "options": "Purchase Order Item Supplied",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "sb_last_purchase",
-      "fieldtype": "Section Break"
-     },
-     {
-      "fieldname": "total_qty",
-      "fieldtype": "Float",
-      "hidden": 1,
-      "label": "Total Quantity",
-      "print_hide_if_no_value": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "base_total",
-      "fieldtype": "Currency",
-      "label": "Total (Company Currency)",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "base_net_total",
-      "fieldtype": "Currency",
-      "label": "Net Total (Company Currency)",
-      "no_copy": 1,
-      "oldfieldname": "net_total",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break_26",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "total",
-      "fieldtype": "Currency",
-      "label": "Total",
-      "options": "currency",
-      "print_hide_if_no_value": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "net_total",
-      "fieldtype": "Currency",
-      "label": "Net Total",
-      "oldfieldname": "net_total_import",
-      "oldfieldtype": "Currency",
-      "options": "currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "total_net_weight",
-      "fieldtype": "Float",
-      "hidden": 1,
-      "label": "Total Net Weight",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "taxes_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "oldfieldtype": "Section Break",
-      "options": "fa fa-money"
-     },
-     {
-      "fieldname": "taxes_and_charges",
-      "fieldtype": "Link",
-      "label": "Purchase Taxes and Charges Template",
-      "oldfieldname": "purchase_other_charges",
-      "oldfieldtype": "Link",
-      "options": "Purchase Taxes and Charges Template",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "column_break_50",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "shipping_rule",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Shipping Rule",
-      "options": "Shipping Rule",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "section_break_52",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "hide_border": 1
-     },
-     {
-      "fieldname": "taxes",
-      "fieldtype": "Table",
-      "label": "Purchase Taxes and Charges",
-      "oldfieldname": "purchase_tax_details",
-      "oldfieldtype": "Table",
-      "options": "Purchase Taxes and Charges"
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "sec_tax_breakup",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Tax Breakup"
-     },
-     {
-      "fieldname": "other_charges_calculation",
-      "fieldtype": "Long Text",
-      "label": "Taxes and Charges Calculation",
-      "no_copy": 1,
-      "oldfieldtype": "HTML",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "totals",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Taxes and Charges",
-      "oldfieldtype": "Section Break",
-      "options": "fa fa-money"
-     },
-     {
-      "depends_on": "base_taxes_and_charges_added",
-      "fieldname": "base_taxes_and_charges_added",
-      "fieldtype": "Currency",
-      "label": "Taxes and Charges Added (Company Currency)",
-      "oldfieldname": "other_charges_added",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "base_taxes_and_charges_deducted",
-      "fieldname": "base_taxes_and_charges_deducted",
-      "fieldtype": "Currency",
-      "label": "Taxes and Charges Deducted (Company Currency)",
-      "oldfieldname": "other_charges_deducted",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "base_total_taxes_and_charges",
-      "fieldname": "base_total_taxes_and_charges",
-      "fieldtype": "Currency",
-      "label": "Total Taxes and Charges (Company Currency)",
-      "no_copy": 1,
-      "oldfieldname": "total_tax",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break_39",
-      "fieldtype": "Column Break"
-     },
-     {
-      "depends_on": "taxes_and_charges_added",
-      "fieldname": "taxes_and_charges_added",
-      "fieldtype": "Currency",
-      "label": "Taxes and Charges Added",
-      "oldfieldname": "other_charges_added_import",
-      "oldfieldtype": "Currency",
-      "options": "currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "taxes_and_charges_deducted",
-      "fieldname": "taxes_and_charges_deducted",
-      "fieldtype": "Currency",
-      "label": "Taxes and Charges Deducted",
-      "oldfieldname": "other_charges_deducted_import",
-      "oldfieldtype": "Currency",
-      "options": "currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "total_taxes_and_charges",
-      "fieldname": "total_taxes_and_charges",
-      "fieldtype": "Currency",
-      "label": "Total Taxes and Charges",
-      "options": "currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "collapsible": 1,
-      "collapsible_depends_on": "apply_discount_on",
-      "fieldname": "discount_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Additional Discount"
-     },
-     {
-      "default": "Grand Total",
-      "fieldname": "apply_discount_on",
-      "fieldtype": "Select",
-      "label": "Apply Additional Discount On",
-      "options": "\nGrand Total\nNet Total",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "base_discount_amount",
-      "fieldtype": "Currency",
-      "label": "Additional Discount Amount (Company Currency)",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break_45",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "additional_discount_percentage",
-      "fieldtype": "Float",
-      "label": "Additional Discount Percentage",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "discount_amount",
-      "fieldtype": "Currency",
-      "label": "Additional Discount Amount",
-      "options": "currency",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "totals_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Totals"
-     },
-     {
-      "fieldname": "base_grand_total",
-      "fieldtype": "Currency",
-      "label": "Grand Total (Company Currency)",
-      "no_copy": 1,
-      "oldfieldname": "grand_total",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "eval:!doc.disable_rounded_total",
-      "fieldname": "base_rounding_adjustment",
-      "fieldtype": "Currency",
-      "label": "Rounding Adjustment (Company Currency)",
-      "no_copy": 1,
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "description": "In Words will be visible once you save the Purchase Order.",
-      "fieldname": "base_in_words",
-      "fieldtype": "Data",
-      "label": "In Words (Company Currency)",
-      "length": 240,
-      "oldfieldname": "in_words",
-      "oldfieldtype": "Data",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "base_rounded_total",
-      "fieldtype": "Currency",
-      "label": "Rounded Total (Company Currency)",
-      "oldfieldname": "rounded_total",
-      "oldfieldtype": "Currency",
-      "options": "Company:company:default_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break4",
-      "fieldtype": "Column Break",
-      "oldfieldtype": "Column Break"
-     },
-     {
-      "fieldname": "grand_total",
-      "fieldtype": "Currency",
-      "in_list_view": 1,
-      "label": "Grand Total(USD)",
-      "oldfieldname": "grand_total_import",
-      "oldfieldtype": "Currency",
-      "options": "currency",
-      "read_only": 1
-     },
-     {
-      "depends_on": "eval:!doc.disable_rounded_total",
-      "fieldname": "rounding_adjustment",
-      "fieldtype": "Currency",
-      "label": "Rounding Adjustment",
-      "no_copy": 1,
-      "options": "currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "rounded_total",
-      "fieldtype": "Currency",
-      "label": "Rounded Total",
-      "options": "currency",
-      "read_only": 1
-     },
-     {
-      "default": "0",
-      "fieldname": "disable_rounded_total",
-      "fieldtype": "Check",
-      "label": "Disable Rounded Total"
-     },
-     {
-      "fieldname": "in_words",
-      "fieldtype": "Data",
-      "label": "In Words",
-      "length": 240,
-      "oldfieldname": "in_words_import",
-      "oldfieldtype": "Data",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "advance_paid",
-      "fieldtype": "Currency",
-      "label": "Advance Paid",
-      "no_copy": 1,
-      "options": "party_account_currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "payment_schedule_section",
-      "fieldtype": "Section Break",
-      "label": "Terms Of Payments"
-     },
-     {
-      "fieldname": "payment_terms_template",
-      "fieldtype": "Link",
-      "label": "Payment Terms Template",
-      "options": "Payment Terms Template",
-      "read_only": 1
-     },
-     {
-      "depends_on": "eval:doc.docstatus === 1",
-      "fieldname": "payment_schedule",
-      "fieldtype": "Table",
-      "label": "Payment Schedule",
-      "no_copy": 1,
-      "options": "Payment Schedule",
-      "print_hide": 1
-     },
-     {
-      "collapsible": 1,
-      "collapsible_depends_on": "terms",
-      "fieldname": "terms_section_break",
-      "fieldtype": "Section Break",
-      "label": "Terms and Conditions",
-      "oldfieldtype": "Section Break",
-      "options": "fa fa-legal"
-     },
-     {
-      "default": "Standard Operating Procedure for Shipping ( SOP)",
-      "fieldname": "tc_name",
-      "fieldtype": "Link",
-      "label": "Terms",
-      "oldfieldname": "tc_name",
-      "oldfieldtype": "Link",
-      "options": "Terms and Conditions",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "terms",
-      "fieldtype": "Text Editor",
-      "label": "Terms and Conditions",
-      "oldfieldname": "terms",
-      "oldfieldtype": "Text Editor"
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "more_info",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "More Information",
-      "oldfieldtype": "Section Break"
-     },
-     {
-      "default": "Draft",
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "hidden": 1,
-      "label": "Status",
-      "no_copy": 1,
-      "oldfieldname": "status",
-      "oldfieldtype": "Select",
-      "options": "\nDraft\nOn Hold\nTo Receive and Bill\nTo Bill\nTo Receive\nCompleted\nCancelled\nClosed\nOpen\nDelivered",
-      "print_hide": 1,
-      "read_only": 1,
-      "reqd": 1,
-      "search_index": 1
-     },
-     {
-      "fieldname": "ref_sq",
-      "fieldtype": "Link",
-      "label": "Supplier Quotation",
-      "no_copy": 1,
-      "oldfieldname": "ref_sq",
-      "oldfieldtype": "Data",
-      "options": "Supplier Quotation",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "party_account_currency",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Party Account Currency",
-      "no_copy": 1,
-      "options": "Currency",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "fieldname": "inter_company_order_reference",
-      "fieldtype": "Link",
-      "label": "Inter Company Order Reference",
-      "options": "Sales Order",
-      "read_only": 1
-     },
-     {
-      "fieldname": "column_break_74",
-      "fieldtype": "Column Break"
-     },
-     {
-      "depends_on": "eval:!doc.__islocal",
-      "fieldname": "per_received",
-      "fieldtype": "Percent",
-      "label": "% Received",
-      "no_copy": 1,
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "depends_on": "eval:!doc.__islocal",
-      "fieldname": "per_billed",
-      "fieldtype": "Percent",
-      "label": "% Billed",
-      "no_copy": 1,
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "column_break5",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Printing Settings",
-      "oldfieldtype": "Column Break",
-      "print_hide": 1,
-      "print_width": "50%",
-      "width": "50%"
-     },
-     {
-      "allow_on_submit": 1,
-      "fieldname": "letter_head",
-      "fieldtype": "Link",
-      "label": "Letter Head",
-      "oldfieldname": "letter_head",
-      "oldfieldtype": "Select",
-      "options": "Letter Head",
-      "print_hide": 1
-     },
-     {
-      "allow_on_submit": 1,
-      "fieldname": "select_print_heading",
-      "fieldtype": "Link",
-      "label": "Print Heading",
-      "no_copy": 1,
-      "oldfieldname": "select_print_heading",
-      "oldfieldtype": "Link",
-      "options": "Print Heading",
-      "print_hide": 1,
-      "report_hide": 1
-     },
-     {
-      "fieldname": "column_break_86",
-      "fieldtype": "Column Break"
-     },
-     {
-      "allow_on_submit": 1,
-      "default": "0",
-      "fieldname": "group_same_items",
-      "fieldtype": "Check",
-      "label": "Group same items",
-      "print_hide": 1
-     },
-     {
-      "fieldname": "language",
-      "fieldtype": "Data",
-      "label": "Print Language",
-      "print_hide": 1
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "subscription_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Subscription Section"
-     },
-     {
-      "allow_on_submit": 1,
-      "fieldname": "from_date",
-      "fieldtype": "Date",
-      "label": "From Date",
-      "no_copy": 1,
-      "print_hide": 1
-     },
-     {
-      "allow_on_submit": 1,
-      "fieldname": "to_date",
-      "fieldtype": "Date",
-      "label": "To Date",
-      "no_copy": 1,
-      "print_hide": 1
-     },
-     {
-      "fieldname": "column_break_97",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "auto_repeat",
-      "fieldtype": "Link",
-      "label": "Auto Repeat",
-      "no_copy": 1,
-      "options": "Auto Repeat",
-      "print_hide": 1,
-      "read_only": 1
-     },
-     {
-      "allow_on_submit": 1,
-      "depends_on": "eval: doc.auto_repeat",
-      "fieldname": "update_auto_repeat_reference",
-      "fieldtype": "Button",
-      "label": "Update Auto Repeat Reference"
-     },
-     {
-      "fieldname": "tax_category",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Tax Category",
-      "options": "Tax Category"
-     },
-     {
-      "depends_on": "supplied_items",
-      "fieldname": "set_reserve_warehouse",
-      "fieldtype": "Link",
-      "label": "Set Reserve Warehouse",
-      "options": "Warehouse"
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "tracking_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Order Status"
-     },
-     {
-      "fieldname": "column_break_75",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "billing_address",
-      "fieldtype": "Link",
-      "hidden": 1,
-      "label": "Company Billing Address",
-      "options": "Address"
-     },
-     {
-      "fieldname": "billing_address_display",
-      "fieldtype": "Small Text",
-      "label": "Billing Address Details",
-      "read_only": 1
-     },
-     {
-      "fieldname": "before_items_section",
-      "fieldtype": "Section Break",
-      "hidden": 1
-     },
-     {
-      "fieldname": "items_col_break",
-      "fieldtype": "Column Break"
-     },
-     {
-      "default": "0",
-      "fetch_from": "supplier.is_internal_supplier",
-      "fieldname": "is_internal_supplier",
-      "fieldtype": "Check",
-      "label": "Is Internal Supplier"
-     },
-     {
-      "fetch_from": "supplier.represents_company",
-      "fieldname": "represents_company",
-      "fieldtype": "Link",
-      "ignore_user_permissions": 1,
-      "label": "Represents Company",
-      "options": "Company",
-      "read_only": 1
-     },
-     {
-      "default": "0",
-      "fieldname": "apply_tds",
-      "fieldtype": "Check",
-      "hidden": 1,
-      "label": "Apply Tax Withholding Amount"
-     },
-     {
-      "depends_on": "eval: doc.apply_tds",
-      "fieldname": "tax_withholding_category",
-      "fieldtype": "Link",
-      "label": "Tax Withholding Category",
-      "options": "Tax Withholding Category"
-     },
-     {
-      "collapsible": 1,
-      "fieldname": "accounting_dimensions_section",
-      "fieldtype": "Section Break",
-      "hidden": 1,
-      "label": "Accounting Dimensions "
-     },
-     {
-      "fieldname": "cost_center",
-      "fieldtype": "Link",
-      "label": "Cost Center",
-      "options": "Cost Center"
-     },
-     {
-      "fieldname": "dimension_col_break",
-      "fieldtype": "Column Break"
-     },
-     {
-      "fieldname": "project",
-      "fieldtype": "Link",
-      "label": "Project",
-      "options": "Project"
-     },
-     {
-      "fieldname": "section_break_3",
-      "fieldtype": "Section Break",
-      "hidden": 1
-     },
-     {
-      "fetch_from": "supplier.supplier_code",
-      "fieldname": "supplier_code",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Supplier Code",
-      "translatable": 1
-     },
-     {
-      "allow_on_submit": 1,
-      "default": "Open",
-      "fieldname": "po_status",
-      "fieldtype": "Select",
-      "hidden": 1,
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "PO Status",
-      "options": "Open\nProposed Ready Date\nReady\nShipped\nCancelled"
-     },
-     {
-      "allow_on_submit": 1,
-      "depends_on": "eval:(doc.po_status==\"Proposed Ready Date\" || doc.po_status==\"Ready\" || doc.po_status==\"Shipped\") && doc.docstatus == 1 ",
-      "fieldname": "proposed_ready_date",
-      "fieldtype": "Date",
-      "label": "Proposed Ready Date",
-      "mandatory_depends_on": "eval:(doc.po_status==\"Proposed Ready Date\" || doc.po_status==\"Ready\") && doc.docstatus == 1",
-      "read_only_depends_on": "eval:doc.po_status==\"Ready\" || doc.po_status==\"Shipped\""
-     },
-     {
-      "fieldname": "column_break_29",
-      "fieldtype": "Column Break"
-     },
-     {
-      "allow_on_submit": 1,
-      "depends_on": "eval:(doc.po_status==\"Shipped\" || doc.po_status==\"Ready\") && doc.docstatus == 1",
-      "fieldname": "ready_date",
-      "fieldtype": "Date",
-      "label": "Ready Date",
-      "read_only": 1
-     }
-    ],
-    "hide_toolbar": 1,
-    "icon": "fa fa-file-text",
-    "idx": 105,
-    "is_submittable": 1,
-    "links": [],
-    "modified": "2022-10-07 00:59:19.638694",
-    "modified_by": "Administrator",
-    "module": "Buying",
-    "name": "Purchase Order",
-    "owner": "Administrator",
-    "permissions": [
-     {
-      "read": 1,
-      "report": 1,
-      "role": "Stock User"
-     },
-     {
-      "amend": 1,
-      "cancel": 1,
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Purchase Manager",
-      "share": 1,
-      "submit": 1,
-      "write": 1
-     },
-     {
-      "amend": 1,
-      "cancel": 1,
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Purchase User",
-      "share": 1,
-      "submit": 1,
-      "write": 1
-     },
-     {
-      "permlevel": 1,
-      "read": 1,
-      "role": "Purchase Manager",
-      "write": 1
-     }
-    ],
-    "search_fields": "status, transaction_date, supplier, grand_total",
-    "show_name_in_global_search": 1,
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "track_changes": 1
+ "actions": [],
+ "allow_auto_repeat": 1,
+ "allow_import": 1,
+ "autoname": "naming_series:",
+ "creation": "2013-05-21 16:16:39",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "engine": "InnoDB",
+ "field_order": [
+  "supplier_section",
+  "naming_series",
+  "section_break_3",
+  "title",
+  "get_items_from_open_material_requests",
+  "apply_tds",
+  "tax_withholding_category",
+  "column_break1",
+  "company",
+  "schedule_date",
+  "order_confirmation_no",
+  "order_confirmation_date",
+  "amended_from",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
+  "project",
+  "drop_ship",
+  "customer",
+  "customer_name",
+  "column_break_19",
+  "customer_contact_person",
+  "customer_contact_display",
+  "customer_contact_mobile",
+  "customer_contact_email",
+  "supplier_name",
+  "section_addresses",
+  "supplier",
+  "column_break_29",
+  "address_display",
+  "supplier_code",
+  "supplier_address",
+  "contact_person",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "col_break_address",
+  "shipping_address",
+  "shipping_address_display",
+  "billing_address",
+  "billing_address_display",
+  "transaction_date",
+  "proposed_ready_date",
+  "ready_date",
+  "currency_and_price_list",
+  "currency",
+  "conversion_rate",
+  "cb_price_list",
+  "buying_price_list",
+  "price_list_currency",
+  "plc_conversion_rate",
+  "ignore_pricing_rule",
+  "sec_warehouse",
+  "is_subcontracted",
+  "col_break_warehouse",
+  "supplier_warehouse",
+  "before_items_section",
+  "scan_barcode",
+  "items_col_break",
+  "set_warehouse",
+  "items_section",
+  "items",
+  "sb_last_purchase",
+  "total_qty",
+  "base_total",
+  "base_net_total",
+  "column_break_26",
+  "total_net_weight",
+  "total",
+  "net_total",
+  "section_break_48",
+  "pricing_rules",
+  "raw_material_details",
+  "set_reserve_warehouse",
+  "supplied_items",
+  "taxes_section",
+  "tax_category",
+  "column_break_50",
+  "shipping_rule",
+  "section_break_52",
+  "taxes_and_charges",
+  "taxes",
+  "sec_tax_breakup",
+  "other_charges_calculation",
+  "totals",
+  "base_taxes_and_charges_added",
+  "base_taxes_and_charges_deducted",
+  "base_total_taxes_and_charges",
+  "column_break_39",
+  "taxes_and_charges_added",
+  "taxes_and_charges_deducted",
+  "total_taxes_and_charges",
+  "discount_section",
+  "apply_discount_on",
+  "base_discount_amount",
+  "column_break_45",
+  "additional_discount_percentage",
+  "discount_amount",
+  "totals_section",
+  "base_grand_total",
+  "base_rounding_adjustment",
+  "base_in_words",
+  "base_rounded_total",
+  "column_break4",
+  "grand_total",
+  "rounding_adjustment",
+  "rounded_total",
+  "disable_rounded_total",
+  "in_words",
+  "advance_paid",
+  "payment_schedule_section",
+  "payment_terms_template",
+  "payment_schedule",
+  "tracking_section",
+  "status",
+  "po_status",
+  "column_break_75",
+  "per_billed",
+  "per_received",
+  "terms_section_break",
+  "tc_name",
+  "terms",
+  "column_break5",
+  "letter_head",
+  "select_print_heading",
+  "column_break_86",
+  "language",
+  "group_same_items",
+  "subscription_section",
+  "from_date",
+  "to_date",
+  "column_break_97",
+  "auto_repeat",
+  "update_auto_repeat_reference",
+  "more_info",
+  "ref_sq",
+  "column_break_74",
+  "party_account_currency",
+  "is_internal_supplier",
+  "represents_company",
+  "inter_company_order_reference",
+  "section_break_142",
+  "purchase_receipt_update"
+ ],
+ "fields": [
+  {
+   "fieldname": "supplier_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "options": "fa fa-user"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "{supplier_name}",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Title",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "default": ".supplier_code.-.##.-.YYYY.",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Series",
+   "no_copy": 1,
+   "oldfieldname": "naming_series",
+   "oldfieldtype": "Select",
+   "options": "PUR-ORD-.YYYY.-\n.supplier_code.-.##.-.YYYY.",
+   "print_hide": 1,
+   "set_only_once": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Supplier",
+   "oldfieldname": "supplier",
+   "oldfieldtype": "Link",
+   "options": "Supplier",
+   "print_hide": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "depends_on": "eval:doc.supplier && doc.docstatus===0 && (!(doc.items && doc.items.length) || (doc.items.length==1 && !doc.items[0].item_code))",
+   "description": "Fetch items based on Default Supplier.",
+   "fieldname": "get_items_from_open_material_requests",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Get Items from Open Material Requests"
+  },
+  {
+   "fetch_from": "supplier.supplier_name",
+   "fieldname": "supplier_name",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Supplier Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "oldfieldname": "company",
+   "oldfieldtype": "Link",
+   "options": "Company",
+   "print_hide": 1,
+   "remember_last_selected_value": 1
+  },
+  {
+   "fieldname": "column_break1",
+   "fieldtype": "Column Break",
+   "oldfieldtype": "Column Break",
+   "print_width": "50%",
+   "width": "50%"
+  },
+  {
+   "default": "Today",
+   "fieldname": "transaction_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "oldfieldname": "transaction_date",
+   "oldfieldtype": "Date",
+   "search_index": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "2099-12-31",
+   "fieldname": "schedule_date",
+   "fieldtype": "Date",
+   "hidden": 1,
+   "label": "Required By"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.docstatus===1",
+   "fieldname": "order_confirmation_no",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Order Confirmation No"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.order_confirmation_no",
+   "fieldname": "order_confirmation_date",
+   "fieldtype": "Date",
+   "label": "Order Confirmation Date"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Amended From",
+   "no_copy": 1,
+   "oldfieldname": "amended_from",
+   "oldfieldtype": "Data",
+   "options": "Purchase Order",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "drop_ship",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Drop Ship"
+  },
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Customer",
+   "options": "Customer",
+   "read_only": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "label": "Customer Name",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_19",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "customer_contact_person",
+   "fieldtype": "Link",
+   "label": "Customer Contact",
+   "options": "Contact"
+  },
+  {
+   "fieldname": "customer_contact_display",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Customer Contact",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "customer_contact_mobile",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Customer Mobile No",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "customer_contact_email",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Customer Contact Email",
+   "options": "Email",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_addresses",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "supplier_address",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Supplier Address Details",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "contact_person",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Supplier Contact",
+   "options": "Contact",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.supplier",
+   "fieldname": "address_display",
+   "fieldtype": "Small Text",
+   "label": "Supplier Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_display",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "in_global_search": 1,
+   "label": "Contact Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_mobile",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Contact Mobile No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_email",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Contact Email",
+   "options": "Email",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "col_break_address",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_address",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Company Shipping Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "shipping_address_display",
+   "fieldtype": "Small Text",
+   "label": "Shipping Address Details",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "currency_and_price_list",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Currency and Price List",
+   "options": "fa fa-tag"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "oldfieldname": "currency",
+   "oldfieldtype": "Select",
+   "options": "Currency",
+   "print_hide": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "conversion_rate",
+   "fieldtype": "Float",
+   "label": "Exchange Rate",
+   "oldfieldname": "conversion_rate",
+   "oldfieldtype": "Currency",
+   "precision": "9",
+   "print_hide": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "cb_price_list",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "buying_price_list",
+   "fieldtype": "Link",
+   "label": "Price List",
+   "options": "Price List",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "price_list_currency",
+   "fieldtype": "Link",
+   "label": "Price List Currency",
+   "options": "Currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "plc_conversion_rate",
+   "fieldtype": "Float",
+   "label": "Price List Exchange Rate",
+   "precision": "9",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule",
+   "no_copy": 1,
+   "permlevel": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "sec_warehouse",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Subcontracting"
+  },
+  {
+   "description": "Sets 'Warehouse' in each row of the Items table.",
+   "fieldname": "set_warehouse",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Set Target Warehouse",
+   "options": "Warehouse",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "col_break_warehouse",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "No",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Select",
+   "label": "Supply Raw Materials",
+   "options": "No\nYes",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.is_subcontracted==\"Yes\"",
+   "fieldname": "supplier_warehouse",
+   "fieldtype": "Link",
+   "label": "Supplier Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "items_section",
+   "fieldtype": "Section Break",
+   "hide_border": 1,
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-shopping-cart"
+  },
+  {
+   "fieldname": "scan_barcode",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Scan Barcode",
+   "options": "Barcode"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Product",
+   "oldfieldname": "po_details",
+   "oldfieldtype": "Table",
+   "options": "Purchase Order Item",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_48",
+   "fieldtype": "Section Break",
+   "label": "Pricing Rules"
+  },
+  {
+   "fieldname": "pricing_rules",
+   "fieldtype": "Table",
+   "label": "Purchase Order Pricing Rule",
+   "options": "Pricing Rule Detail",
+   "read_only": 1
+  },
+  {
+   "collapsible_depends_on": "supplied_items",
+   "fieldname": "raw_material_details",
+   "fieldtype": "Section Break",
+   "label": "Raw Materials Supplied"
+  },
+  {
+   "fieldname": "supplied_items",
+   "fieldtype": "Table",
+   "label": "Supplied Items",
+   "no_copy": 1,
+   "oldfieldname": "po_raw_material_details",
+   "oldfieldtype": "Table",
+   "options": "Purchase Order Item Supplied",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "sb_last_purchase",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "total_qty",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Total Quantity",
+   "print_hide_if_no_value": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_total",
+   "fieldtype": "Currency",
+   "label": "Total (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_net_total",
+   "fieldtype": "Currency",
+   "label": "Net Total (Company Currency)",
+   "no_copy": 1,
+   "oldfieldname": "net_total",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_26",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total",
+   "fieldtype": "Currency",
+   "label": "Total",
+   "options": "currency",
+   "print_hide_if_no_value": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_total",
+   "fieldtype": "Currency",
+   "label": "Net Total",
+   "oldfieldname": "net_total_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_net_weight",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Total Net Weight",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money"
+  },
+  {
+   "fieldname": "taxes_and_charges",
+   "fieldtype": "Link",
+   "label": "Purchase Taxes and Charges Template",
+   "oldfieldname": "purchase_other_charges",
+   "oldfieldtype": "Link",
+   "options": "Purchase Taxes and Charges Template",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_50",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_rule",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Shipping Rule",
+   "options": "Shipping Rule",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "section_break_52",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "hide_border": 1
+  },
+  {
+   "fieldname": "taxes",
+   "fieldtype": "Table",
+   "label": "Purchase Taxes and Charges",
+   "oldfieldname": "purchase_tax_details",
+   "oldfieldtype": "Table",
+   "options": "Purchase Taxes and Charges"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "sec_tax_breakup",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Tax Breakup"
+  },
+  {
+   "fieldname": "other_charges_calculation",
+   "fieldtype": "Long Text",
+   "label": "Taxes and Charges Calculation",
+   "no_copy": 1,
+   "oldfieldtype": "HTML",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "totals",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Taxes and Charges",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money"
+  },
+  {
+   "depends_on": "base_taxes_and_charges_added",
+   "fieldname": "base_taxes_and_charges_added",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Added (Company Currency)",
+   "oldfieldname": "other_charges_added",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "base_taxes_and_charges_deducted",
+   "fieldname": "base_taxes_and_charges_deducted",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Deducted (Company Currency)",
+   "oldfieldname": "other_charges_deducted",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "base_total_taxes_and_charges",
+   "fieldname": "base_total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges (Company Currency)",
+   "no_copy": 1,
+   "oldfieldname": "total_tax",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_39",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "taxes_and_charges_added",
+   "fieldname": "taxes_and_charges_added",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Added",
+   "oldfieldname": "other_charges_added_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "taxes_and_charges_deducted",
+   "fieldname": "taxes_and_charges_deducted",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Deducted",
+   "oldfieldname": "other_charges_deducted_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "total_taxes_and_charges",
+   "fieldname": "total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "apply_discount_on",
+   "fieldname": "discount_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Additional Discount"
+  },
+  {
+   "default": "Grand Total",
+   "fieldname": "apply_discount_on",
+   "fieldtype": "Select",
+   "label": "Apply Additional Discount On",
+   "options": "\nGrand Total\nNet Total",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "base_discount_amount",
+   "fieldtype": "Currency",
+   "label": "Additional Discount Amount (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_45",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "additional_discount_percentage",
+   "fieldtype": "Float",
+   "label": "Additional Discount Percentage",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "discount_amount",
+   "fieldtype": "Currency",
+   "label": "Additional Discount Amount",
+   "options": "currency",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "totals_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Totals"
+  },
+  {
+   "fieldname": "base_grand_total",
+   "fieldtype": "Currency",
+   "label": "Grand Total (Company Currency)",
+   "no_copy": 1,
+   "oldfieldname": "grand_total",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.disable_rounded_total",
+   "fieldname": "base_rounding_adjustment",
+   "fieldtype": "Currency",
+   "label": "Rounding Adjustment (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "description": "In Words will be visible once you save the Purchase Order.",
+   "fieldname": "base_in_words",
+   "fieldtype": "Data",
+   "label": "In Words (Company Currency)",
+   "length": 240,
+   "oldfieldname": "in_words",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_rounded_total",
+   "fieldtype": "Currency",
+   "label": "Rounded Total (Company Currency)",
+   "oldfieldname": "rounded_total",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break4",
+   "fieldtype": "Column Break",
+   "oldfieldtype": "Column Break"
+  },
+  {
+   "fieldname": "grand_total",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Grand Total(USD)",
+   "oldfieldname": "grand_total_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.disable_rounded_total",
+   "fieldname": "rounding_adjustment",
+   "fieldtype": "Currency",
+   "label": "Rounding Adjustment",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "rounded_total",
+   "fieldtype": "Currency",
+   "label": "Rounded Total",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_rounded_total",
+   "fieldtype": "Check",
+   "label": "Disable Rounded Total"
+  },
+  {
+   "fieldname": "in_words",
+   "fieldtype": "Data",
+   "label": "In Words",
+   "length": 240,
+   "oldfieldname": "in_words_import",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "advance_paid",
+   "fieldtype": "Currency",
+   "label": "Advance Paid",
+   "no_copy": 1,
+   "options": "party_account_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "payment_schedule_section",
+   "fieldtype": "Section Break",
+   "label": "Terms Of Payments"
+  },
+  {
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.docstatus === 1",
+   "fieldname": "payment_schedule",
+   "fieldtype": "Table",
+   "label": "Payment Schedule",
+   "no_copy": 1,
+   "options": "Payment Schedule",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "terms",
+   "fieldname": "terms_section_break",
+   "fieldtype": "Section Break",
+   "label": "Terms and Conditions",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-legal"
+  },
+  {
+   "default": "Standard Operating Procedure for Shipping ( SOP)",
+   "fieldname": "tc_name",
+   "fieldtype": "Link",
+   "label": "Terms",
+   "oldfieldname": "tc_name",
+   "oldfieldtype": "Link",
+   "options": "Terms and Conditions",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "terms",
+   "fieldtype": "Text Editor",
+   "label": "Terms and Conditions",
+   "oldfieldname": "terms",
+   "oldfieldtype": "Text Editor"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "more_info",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "More Information",
+   "oldfieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "Open",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "oldfieldname": "status",
+   "oldfieldtype": "Select",
+   "options": "\nOpen\nProposed Ready Date\nPartially Ready\nReady\nShipped\nCancelled",
+   "print_hide": 1,
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "ref_sq",
+   "fieldtype": "Link",
+   "label": "Supplier Quotation",
+   "no_copy": 1,
+   "oldfieldname": "ref_sq",
+   "oldfieldtype": "Data",
+   "options": "Supplier Quotation",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "party_account_currency",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Party Account Currency",
+   "no_copy": 1,
+   "options": "Currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "inter_company_order_reference",
+   "fieldtype": "Link",
+   "label": "Inter Company Order Reference",
+   "options": "Sales Order",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_74",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "per_received",
+   "fieldtype": "Percent",
+   "label": "% Received",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "per_billed",
+   "fieldtype": "Percent",
+   "label": "% Billed",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "column_break5",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Printing Settings",
+   "oldfieldtype": "Column Break",
+   "print_hide": 1,
+   "print_width": "50%",
+   "width": "50%"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "letter_head",
+   "fieldtype": "Link",
+   "label": "Letter Head",
+   "oldfieldname": "letter_head",
+   "oldfieldtype": "Select",
+   "options": "Letter Head",
+   "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "select_print_heading",
+   "fieldtype": "Link",
+   "label": "Print Heading",
+   "no_copy": 1,
+   "oldfieldname": "select_print_heading",
+   "oldfieldtype": "Link",
+   "options": "Print Heading",
+   "print_hide": 1,
+   "report_hide": 1
+  },
+  {
+   "fieldname": "column_break_86",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "group_same_items",
+   "fieldtype": "Check",
+   "label": "Group same items",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "label": "Print Language",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "subscription_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Subscription Section"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "label": "From Date",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "label": "To Date",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_97",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "auto_repeat",
+   "fieldtype": "Link",
+   "label": "Auto Repeat",
+   "no_copy": 1,
+   "options": "Auto Repeat",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.auto_repeat",
+   "fieldname": "update_auto_repeat_reference",
+   "fieldtype": "Button",
+   "label": "Update Auto Repeat Reference"
+  },
+  {
+   "fieldname": "tax_category",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Tax Category",
+   "options": "Tax Category"
+  },
+  {
+   "depends_on": "supplied_items",
+   "fieldname": "set_reserve_warehouse",
+   "fieldtype": "Link",
+   "label": "Set Reserve Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "tracking_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Order Status"
+  },
+  {
+   "fieldname": "column_break_75",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "billing_address",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Company Billing Address",
+   "options": "Address"
+  },
+  {
+   "fieldname": "billing_address_display",
+   "fieldtype": "Small Text",
+   "label": "Billing Address Details",
+   "read_only": 1
+  },
+  {
+   "fieldname": "before_items_section",
+   "fieldtype": "Section Break",
+   "hidden": 1
+  },
+  {
+   "fieldname": "items_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fetch_from": "supplier.is_internal_supplier",
+   "fieldname": "is_internal_supplier",
+   "fieldtype": "Check",
+   "label": "Is Internal Supplier"
+  },
+  {
+   "fetch_from": "supplier.represents_company",
+   "fieldname": "represents_company",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Represents Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "apply_tds",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Apply Tax Withholding Amount"
+  },
+  {
+   "depends_on": "eval: doc.apply_tds",
+   "fieldname": "tax_withholding_category",
+   "fieldtype": "Link",
+   "label": "Tax Withholding Category",
+   "options": "Tax Withholding Category"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Accounting Dimensions "
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
+  },
+  {
+   "fieldname": "section_break_3",
+   "fieldtype": "Section Break",
+   "hidden": 1
+  },
+  {
+   "fetch_from": "supplier.supplier_code",
+   "fieldname": "supplier_code",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Supplier Code",
+   "translatable": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "Open",
+   "fieldname": "po_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "PO Status",
+   "options": "Open\nProposed Ready Date\nPartially Ready\nReady\nShipped\nCancelled"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:(doc.po_status==\"Proposed Ready Date\" || doc.po_status==\"Ready\" || doc.po_status==\"Shipped\") && doc.docstatus == 1 ",
+   "fieldname": "proposed_ready_date",
+   "fieldtype": "Date",
+   "label": "Proposed Ready Date",
+   "mandatory_depends_on": "eval:(doc.po_status==\"Proposed Ready Date\" || doc.po_status==\"Ready\") && doc.docstatus == 1",
+   "read_only_depends_on": "eval:doc.status !=\"Proposed Ready Date\""
+  },
+  {
+   "fieldname": "column_break_29",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:(doc.po_status==\"Shipped\" || doc.po_status==\"Ready\") && doc.docstatus == 1",
+   "fieldname": "ready_date",
+   "fieldtype": "Date",
+   "label": "Ready Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_142",
+   "fieldtype": "Section Break",
+   "hidden": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "purchase_receipt_update",
+   "fieldtype": "Table",
+   "in_standard_filter": 1,
+   "label": "Purchase Receipt Update",
+   "options": "Purchase Receipt Update in PO"
+  }
+ ],
+ "hide_toolbar": 1,
+ "icon": "fa fa-file-text",
+ "idx": 105,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2022-11-17 05:52:56.246252",
+ "modified_by": "Administrator",
+ "module": "Buying",
+ "name": "Purchase Order",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "report": 1,
+   "role": "Stock User"
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Purchase Manager",
+   "write": 1
+  }
+ ],
+ "search_fields": "status, transaction_date, supplier, grand_total",
+ "show_name_in_global_search": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
 }

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -53,12 +53,6 @@
   "pricing_rules",
   "stock_uom_rate",
   "is_free_item",
-  "batch_details_section",
-  "batch_number",
-  "column_break_49",
-  "manufacturing_date",
-  "column_break_51",
-  "expiry_date",
   "section_break_29",
   "net_rate",
   "net_amount",
@@ -84,7 +78,10 @@
   "item_group",
   "brand",
   "section_break_56",
+  "proposed_qty",
   "received_qty",
+  "shipped_qty",
+  "remaining_qty",
   "returned_qty",
   "column_break_60",
   "billed_amt",
@@ -637,9 +634,11 @@
    "width": "100px"
   },
   {
+   "columns": 1,
    "depends_on": "received_qty",
    "fieldname": "received_qty",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Received Qty",
    "no_copy": 1,
    "oldfieldname": "received_qty",
@@ -924,52 +923,40 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "batch_details_section",
-   "fieldtype": "Section Break",
-   "label": "Batch Details",
+   "allow_on_submit": 1,
+   "columns": 1,
+   "fieldname": "proposed_qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Proposed Qty",
+   "precision": "0",
    "read_only": 1
   },
   {
    "allow_on_submit": 1,
    "columns": 1,
-   "fieldname": "manufacturing_date",
-   "fieldtype": "Date",
+   "fieldname": "remaining_qty",
+   "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Manufacturing Date",
+   "label": "Remaining Qty",
+   "precision": "0",
    "read_only": 1
   },
   {
    "allow_on_submit": 1,
-   "columns": 1,
-   "fieldname": "expiry_date",
-   "fieldtype": "Date",
-   "in_list_view": 1,
-   "label": "Expiry Date",
-   "read_only": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "columns": 1,
-   "fieldname": "batch_number",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Batch No",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_49",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_51",
-   "fieldtype": "Column Break"
+   "fieldname": "shipped_qty",
+   "fieldtype": "Float",
+   "label": "Shipped Qty",
+   "read_only": 1,
+   "precision": "0"
+
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-04 09:14:45.523117",
+ "modified": "2022-11-18 06:13:02.016663",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -75,24 +75,19 @@ status_map = {
 		["On Hold", "eval:self.status=='On Hold'"],
 	],
 	"Purchase Order": [
-		["Draft", None],
+		["Open", None],
 		[
-			"To Receive and Bill",
-			"eval:self.per_received < 100 and self.per_billed < 100 and self.docstatus == 1",
-		],
-		["To Bill", "eval:self.per_received >= 100 and self.per_billed < 100 and self.docstatus == 1"],
-		[
-			"To Receive",
-			"eval:self.per_received < 100 and self.per_billed == 100 and self.docstatus == 1",
+			"Partially Ready",
+			"eval:self.per_received < 100 and self.per_received > 0 and self.per_billed < 100 and self.docstatus == 1",
 		],
 		[
-			"Completed",
-			"eval:self.per_received >= 100 and self.per_billed == 100 and self.docstatus == 1",
+			"Ready",
+			"eval:self.per_received >= 100 and self.docstatus == 1",
 		],
-		["Delivered", "eval:self.status=='Delivered'"],
+		["Proposed Ready Date", "eval:self.status=='Proposed Ready Date' and self.per_received == 0"],
 		["Cancelled", "eval:self.docstatus==2"],
-		["On Hold", "eval:self.status=='On Hold'"],
-		["Closed", "eval:self.status=='Closed'"],
+		["Ready", "eval:self.status=='Ready'"],
+		["Shipped", "eval:self.po_status=='Shipped'"]
 	],
 	"Delivery Note": [
 		["Draft", None],
@@ -104,10 +99,11 @@ status_map = {
 	],
 	"Logistic Notice": [
 		["Open", None],
-		["Open", "eval:self.per_billed < 100 and self.docstatus == 1"],
+		["Open", "eval:self.per_billed < 100 and self.docstatus == 1 and self.ship_to != 'Customer'"],
+		["Delivered To Customer", "eval:self.per_billed < 100 and self.docstatus == 1 and self.ship_to == 'Customer'"],
 	],
 	"Purchase Receipt": [
-		["Draft", None],
+		["Open", None],
 		["Ready", "eval:self.per_billed < 100 and self.docstatus == 1"],
 		["Return Issued", "eval:self.per_returned == 100 and self.docstatus == 1"],
 		["Completed", "eval:self.per_billed == 100 and self.docstatus == 1"],


### PR DESCRIPTION
### Changed working flow on purchase order to purchase receipt.

1. Purchase order status changes from po_status field to status field and update status from status_updater.py file.
2. Allow create many Purchase receipt from one purchase order until remaining qty would not be 0.
3. Update Proposed qty in purchase order for particular product from purchase receipt item table on save.